### PR TITLE
new ecg refactor (2 threads)

### DIFF
--- a/TagV3.0_U575VGT/Core/Inc/Lib Inc/state_machine.h
+++ b/TagV3.0_U575VGT/Core/Inc/Lib Inc/state_machine.h
@@ -11,7 +11,6 @@
 #include "tx_api.h"
 
 #define IS_SIMULATING false
-
 //Should correspond with the state types enum below
 #define SIMULATING_STATE 0
 

--- a/TagV3.0_U575VGT/Core/Inc/Lib Inc/threads.h
+++ b/TagV3.0_U575VGT/Core/Inc/Lib Inc/threads.h
@@ -21,6 +21,7 @@
 #include "Sensor Inc/audio.h"
 #include "Sensor Inc/BNO08x.h"
 #include "Sensor Inc/ECG.h"
+#include "Sensor Inc/ECG_SD.h"
 #include "Lib Inc/state_machine.h"
 #include "Recovery Inc/Aprs.h"
 
@@ -31,6 +32,7 @@ typedef enum __TX_THREAD_LIST {
 	AUDIO_THREAD,
 	IMU_THREAD,
 	ECG_THREAD,
+	ECG_SD_THREAD,
 	APRS_THREAD,
 	NUM_THREADS //DO NOT ADD THREAD ENUMS BELOW THIS
 }Thread;
@@ -108,6 +110,17 @@ static Thread_ConfigTypeDef threadConfigList[NUM_THREADS] = {
 				.thread_stack_size = 6500,
 				.priority = 5,
 				.preempt_threshold = 5,
+				.timeslice = TX_NO_TIME_SLICE,
+				.start = TX_DONT_START
+		},
+		{
+				//ECG_SD Thread
+				.thread_name = "ECG SD Thread",
+				.thread_entry_function = ecg_sd_thread_entry,
+				.thread_input = 0x1234,
+				.thread_stack_size = 2048,
+				.priority = 6,
+				.preempt_threshold = 6,
 				.timeslice = TX_NO_TIME_SLICE,
 				.start = TX_DONT_START
 		},

--- a/TagV3.0_U575VGT/Core/Inc/Sensor Inc/ECG.h
+++ b/TagV3.0_U575VGT/Core/Inc/Sensor Inc/ECG.h
@@ -5,7 +5,7 @@
  *      Author: Kaveet
  *
  *
- *  The I2C driver for the ADS1219 ADC on the ECG board.
+ *  The I2C data collection driver for the ADS1219 ADC on the ECG board.
  *
  *  ADC datasheet: https://www.ti.com/lit/ds/symlink/ads1219.pdf?ts=1686494723332&ref_url=https%253A%252F%252Fwww.google.com%252F
  *
@@ -66,9 +66,11 @@
 // Bit 0: Vref (0 = internal/2.048V, 1 = external reference)
 #define ECG_ADC_DEFAULT_CONFIG_REGISTER 0b00001110
 
+//The number of ECG Samples to collect before writing to the SD card. This should ALWAYS be an even number.
+#define ECG_BUFFER_SIZE 1000
 
-//The number of ECG Samples to collect before writing to the SD card
-#define ECG_NUM_SAMPLES 1000
+//A half buffer size, since our buffer is split in half
+#define ECG_HALF_BUFFER_SIZE (ECG_BUFFER_SIZE / 2)
 
 //Struct for holding ECG data (data and timestamps)
 typedef struct __ECG_Data_Typedef {

--- a/TagV3.0_U575VGT/Core/Inc/Sensor Inc/ECG.h
+++ b/TagV3.0_U575VGT/Core/Inc/Sensor Inc/ECG.h
@@ -55,8 +55,9 @@
 //ThreadX flag bit for when data is ready
 #define ECG_DATA_READY_FLAG 0x1
 
-//ThreadX flag bit for stopping the ecg thread (exit data collection)
-#define ECG_STOP_THREAD_FLAG 0x2
+//ThreadX flag bit for stopping the ecg data and SD writing threads
+#define ECG_STOP_DATA_THREAD_FLAG 0x2
+#define ECG_STOP_SD_THREAD_FLAG 0x4
 
 //ECG configuration register has the following structure:
 // Bit 7-5: MUX Electrode Selection

--- a/TagV3.0_U575VGT/Core/Inc/Sensor Inc/ECG_SD.h
+++ b/TagV3.0_U575VGT/Core/Inc/Sensor Inc/ECG_SD.h
@@ -1,0 +1,28 @@
+/*
+ * ECG_SD.h
+ *
+ *  Created on: Aug 8, 2023
+ *      Author: Kaveet
+ *
+ *  The thread responsible for writing the ECG data collected by the ECG Data collection driver (ECG.h) to the SD card.
+ *
+ *  The two threads share a buffer split in half, with each half protected by a mutex.
+ *
+ *  When the data collection driver finishes filling up one half, this thread will begin writing that thread to the SD card.
+ *
+ *  This avoids missing data during the write period.
+ *
+ *  This process is continuously repeated through a circular buffer.
+ *
+ *  Essentially, this tries to "mock" a circular DMA buffer using RTOS threads and a mutex
+ */
+#ifndef INC_SENSOR_INC_ECG_SD_H_
+#define INC_SENSOR_INC_ECG_SD_H_
+
+#include "Sensor Inc/ECG.h"
+#include "tx_api.h"
+
+//Our thread entry for the ECG sd card writing thread
+void ecg_sd_thread_entry(ULONG thread_input);
+
+#endif /* INC_SENSOR_INC_ECG_SD_H_ */

--- a/TagV3.0_U575VGT/Core/Src/Lib Src/state_machine.c
+++ b/TagV3.0_U575VGT/Core/Src/Lib Src/state_machine.c
@@ -105,7 +105,7 @@ void hard_exit_data_capture(){
 	//Signal data collection threads to stop running (and they should never run again)
 	tx_event_flags_set(&audio_event_flags_group, AUDIO_STOP_THREAD_FLAG, TX_OR);
 	tx_event_flags_set(&imu_event_flags_group, IMU_STOP_THREAD_FLAG, TX_OR);
-	tx_event_flags_set(&ecg_event_flags_group, ECG_STOP_THREAD_FLAG, TX_OR);
+	tx_event_flags_set(&ecg_event_flags_group, ECG_STOP_DATA_THREAD_FLAG, TX_OR);
 }
 
 void enter_recovery(){

--- a/TagV3.0_U575VGT/Core/Src/Sensor Src/ECG.c
+++ b/TagV3.0_U575VGT/Core/Src/Sensor Src/ECG.c
@@ -16,54 +16,27 @@ extern I2C_HandleTypeDef hi2c4;
 
 extern Thread_HandleTypeDef threads[NUM_THREADS];
 
-//FileX variables
-extern FX_MEDIA        sdio_disk;
-extern ALIGN_32BYTES (uint32_t fx_sd_media_memory[FX_STM32_SD_DEFAULT_SECTOR_SIZE / sizeof(uint32_t)]);
-
+//Event flags (shared with ecg sd thread)
 TX_EVENT_FLAGS_GROUP ecg_event_flags_group;
 
-bool ecg_running = 0;
-bool ecg_writing = 0;
-uint16_t good_ecg_data = 0;
+//Mutexes (shared with ecg sd thread)
+TX_MUTEX ecg_first_half_mutex;
+TX_MUTEX ecg_second_half_mutex;
 
-void ecg_SDWriteComplete(FX_FILE *file){
-	//Indicate that we are no longer writing to the SD card
-	ecg_writing = false;
-}
+//Array for holding ECG data. The buffer is split in half and shared with the ECG_SD thread.
+ECG_Data ecg_data[2][ECG_HALF_BUFFER_SIZE] = {0};
+
+bool ecg_running = 0;
+uint16_t good_ecg_data = 0;
 
 void ecg_thread_entry(ULONG thread_input){
 
 	//Create our flag that indicates when data is ready
 	tx_event_flags_create(&ecg_event_flags_group, "ECG Event Flags");
 
-	FX_FILE ecg_file = {};
-
-	//Create our binary file for dumping ecg data
-	UINT fx_result = FX_SUCCESS;
-	fx_result = fx_file_create(&sdio_disk, "ecg_test.bin");
-	if((fx_result != FX_SUCCESS) && (fx_result != FX_ALREADY_CREATED)){
-	  Error_Handler();
-	}
-
-	//Open the file
-	fx_result = fx_file_open(&sdio_disk, &ecg_file, "ecg_test.bin", FX_OPEN_FOR_WRITE);
-	if(fx_result != FX_SUCCESS){
-	  Error_Handler();
-	}
-
-	//Set our "write complete" callback function
-	fx_result = fx_file_write_notify_set(&ecg_file, ecg_SDWriteComplete);
-	if(fx_result != FX_SUCCESS){
-	  Error_Handler();
-	}
-
-	//Data array for holding multiple ECG samples (so we can collect them and write to the SD card in batches)
-	ECG_Data ecg_data[ECG_NUM_SAMPLES] = {0};
-
-	//Do a dummy write for the beginning of the file
-	ecg_writing = true;
-	fx_file_write(&ecg_file, ecg_data, sizeof(float) * ECG_NUM_SAMPLES);
-	while (ecg_writing);
+	//Create mutexes
+	tx_mutex_create(&ecg_first_half_mutex, "ECG First Half Mutex", TX_INHERIT);
+	tx_mutex_create(&ecg_second_half_mutex, "ECG Second Half Mutex", TX_INHERIT);
 
 	//Declare ecg handler and initialize chip
 	ECG_HandleTypeDef ecg;
@@ -72,10 +45,16 @@ void ecg_thread_entry(ULONG thread_input){
 	//Enable our interrupt handler (signals when data is ready)
 	HAL_NVIC_EnableIRQ(EXTI14_IRQn);
 
+	//Start data collection thread since we're ready to collect data
+	tx_thread_resume(&threads[ECG_SD_THREAD].thread);
+
 	while(1){
 
+		//Acquire first half mutex to start collecting data
+		tx_mutex_get(&ecg_first_half_mutex, TX_WAIT_FOREVER);
+
 		//Collect a batch of samples
-		for (uint16_t index = 0; index < ECG_NUM_SAMPLES; index++){
+		for (uint16_t index = 0; index < ECG_HALF_BUFFER_SIZE; index++){
 
 			//holds event flags
 			ULONG actual_events;
@@ -91,17 +70,43 @@ void ecg_thread_entry(ULONG thread_input){
 				good_ecg_data++;
 			}
 
-			ecg_data[index] = ecg.data;
+			//Fill up the first half buffer
+			ecg_data[0][index] = ecg.data;
 
 			ecg_running = false;
 		}
 
-		//We've collected all the samples we need, write them to SD card
-		ecg_writing = true;
-		fx_file_write(&ecg_file, ecg_data, sizeof(ECG_Data) * ECG_NUM_SAMPLES);
+		//Release the first half mutex to signal the ECG_SD thread that it can start writing
+		tx_mutex_put(&ecg_first_half_mutex);
 
-		//Poll for completion
-		while (ecg_writing);
+		//Acquire the second half mutex to fill it up
+		tx_mutex_get(&ecg_second_half_mutex, TX_WAIT_FOREVER);
+
+		//Collect a batch of samples
+		for (uint16_t index = 0; index < ECG_HALF_BUFFER_SIZE; index++){
+
+			//holds event flags
+			ULONG actual_events;
+
+			//We've initialized the ECG to be in continuous conversion mode, and we have an interrupt line signalling when data is ready.
+			//Thus, wait for our flag to be set in the interrupt handler. This function call will block the entire task until we receive the data.
+			tx_event_flags_get(&ecg_event_flags_group, ECG_DATA_READY_FLAG, TX_OR_CLEAR, &actual_events, TX_WAIT_FOREVER);
+
+			ecg_running = true;
+
+			//New data is ready, retrieve it
+			if (ecg_read_adc(&ecg) == HAL_OK){
+				good_ecg_data++;
+			}
+
+			//Fill up the second half buffer
+			ecg_data[1][index] = ecg.data;
+
+			ecg_running = false;
+		}
+
+		//Release second half mutex so the ECG_SD thread can write to it
+		tx_mutex_put(&ecg_second_half_mutex);
 
 		good_ecg_data = 0;
 	}

--- a/TagV3.0_U575VGT/Core/Src/Sensor Src/ECG.c
+++ b/TagV3.0_U575VGT/Core/Src/Sensor Src/ECG.c
@@ -112,17 +112,16 @@ void ecg_thread_entry(ULONG thread_input){
 
 		//Check to see if there was a stop thread request. Put very little wait time so its essentially an instant check
 		ULONG actual_flags = 0;
-		tx_event_flags_get(&ecg_event_flags_group, ECG_STOP_THREAD_FLAG, TX_OR_CLEAR, &actual_flags, 1);
+		tx_event_flags_get(&ecg_event_flags_group, ECG_STOP_DATA_THREAD_FLAG, TX_OR_CLEAR, &actual_flags, 1);
 
 		//If there was something set cleanup the thread
-		if (actual_flags & ECG_STOP_THREAD_FLAG){
+		if (actual_flags & ECG_STOP_DATA_THREAD_FLAG){
 
-			//Close the file and suspend our interrupt
-			fx_file_close(&ecg_file);
+			//Suspend our interrupt to stop new data from coming in
 			HAL_NVIC_DisableIRQ(EXTI14_IRQn);
 
-			//Delete threadx event flags and terminate the thread
-			tx_event_flags_delete(&ecg_event_flags_group);
+			//Signal SD card thread to stop, and terminate this thread
+			tx_event_flags_set(&ecg_event_flags_group, ECG_STOP_SD_THREAD_FLAG, TX_OR);
 			tx_thread_terminate(&threads[ECG_THREAD].thread);
 		}
 

--- a/TagV3.0_U575VGT/Core/Src/Sensor Src/ECG_SD.c
+++ b/TagV3.0_U575VGT/Core/Src/Sensor Src/ECG_SD.c
@@ -1,0 +1,92 @@
+/*
+ * ECG_SD.c
+ *
+ *  Created on: Aug 8, 2023
+ *      Author: Kaveet
+ *
+ * See Header file (ECG_SD.H) for details.
+ */
+
+#include "Sensor Inc/ECG_SD.h"
+#include "app_filex.h"
+#include <stdbool.h>
+
+//FileX variables
+extern FX_MEDIA        sdio_disk;
+extern ALIGN_32BYTES (uint32_t fx_sd_media_memory[FX_STM32_SD_DEFAULT_SECTOR_SIZE / sizeof(uint32_t)]);
+
+extern TX_EVENT_FLAGS_GROUP ecg_event_flags_group;
+
+extern TX_MUTEX ecg_first_half_mutex;
+extern TX_MUTEX ecg_second_half_mutex;
+
+//Array for holding ECG data. The buffer is split in half and shared with the ECG_SD thread.
+extern ECG_Data ecg_data[2][ECG_HALF_BUFFER_SIZE];
+
+//DEBUG
+uint8_t ecg_writing = 0;
+
+void ecg_SDWriteComplete(FX_FILE *file){
+	//Indicate that we are no longer writing to the SD card
+	ecg_writing = 0;
+}
+
+void ecg_sd_thread_entry(ULONG thread_input){
+
+	FX_FILE ecg_file = {};
+
+	//Create our binary file for dumping ecg data
+	UINT fx_result = FX_SUCCESS;
+	fx_result = fx_file_create(&sdio_disk, "ecg_test.bin");
+	if((fx_result != FX_SUCCESS) && (fx_result != FX_ALREADY_CREATED)){
+	  Error_Handler();
+	}
+
+	//Open the file
+	fx_result = fx_file_open(&sdio_disk, &ecg_file, "ecg_test.bin", FX_OPEN_FOR_WRITE);
+	if(fx_result != FX_SUCCESS){
+	  Error_Handler();
+	}
+
+	//Set our "write complete" callback function
+	fx_result = fx_file_write_notify_set(&ecg_file, ecg_SDWriteComplete);
+	if(fx_result != FX_SUCCESS){
+	  Error_Handler();
+	}
+
+	//Do a dummy write for the beginning of the file
+	ecg_writing = 250; //Set to 250 for easier validation in cube monitor (eventually make this true and false)
+	fx_file_write(&ecg_file, ecg_data, sizeof(float) * ECG_BUFFER_SIZE);
+	while (ecg_writing);
+
+	while (1){
+
+		//Wait for first half buffer to fill up
+		tx_mutex_get(&ecg_first_half_mutex, TX_WAIT_FOREVER);
+
+		//We've collected all the samples we need, write them to SD card
+		ecg_writing = 250; //Set to 250 for easier validation in cube monitor (eventually make this true and false)
+		fx_file_write(&ecg_file, ecg_data[0], sizeof(ECG_Data) * ECG_HALF_BUFFER_SIZE);
+
+		//Poll for completion
+		while (ecg_writing);
+
+		//Release first half mutex (done writing)
+		tx_mutex_put(&ecg_first_half_mutex);
+
+		//Wait for second half buffer to fill up
+		tx_mutex_get(&ecg_second_half_mutex, TX_WAIT_FOREVER);
+
+		//We've collected all the samples we need, write them to SD card
+		ecg_writing = 250; //Set to 250 for easier validation in cube monitor (eventually make this true and false)
+		fx_file_write(&ecg_file, ecg_data[1], sizeof(ECG_Data) * ECG_HALF_BUFFER_SIZE);
+
+		//Poll for completion
+		while (ecg_writing);
+
+		//Release first half mutex (done writing)
+		tx_mutex_put(&ecg_second_half_mutex);
+	}
+}
+
+


### PR DESCRIPTION
Refactored ECG thread to use 2 seperate RTOS threads

- Split the data buffer in half
- One thread collects the data and the other writes it to the SD card
- Data collection thread fills up first half, moves onto the second while the other one writes the first to the SD card
- Each half buffer is protected with a mutex to prevent data race